### PR TITLE
Feature/initial setup

### DIFF
--- a/src/Webstorm.AzureDevOps.Iterations.Generate/Program.cs
+++ b/src/Webstorm.AzureDevOps.Iterations.Generate/Program.cs
@@ -1,12 +1,190 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi.Types;
+using Microsoft.TeamFoundation.Work.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
 
 namespace Webstorm.AzureDevOps.Iterations.Generate
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private const string AppSettingsFile = "appsettings.json";
+        private const string FinishDateKey = "finishDate";
+        private const string StartDateKey = "startDate";
+
+        private static IConfiguration _configuration;
+        private static string _currentProject;
+        private static List<WebApiTeam> _currentTeams;
+        private static int _iterationLength;
+        private static TeamHttpClient _teamHttpClient;
+        private static DateTime _today;
+        private static VssConnection _vssConnection;
+        private static WorkHttpClient _workHttpClient;
+        private static WorkItemTrackingHttpClient _workItemTrackingHttpClient;
+
+        private static void AssignIterationToTeams(WorkItemClassificationNode workItemClassificationNode)
         {
-            Console.WriteLine("Hello World!");
+            var teamSettingsIteration = new TeamSettingsIteration { Id = workItemClassificationNode.Identifier };
+
+            foreach (var teamContext in _currentTeams.Select(webApiTeam => new TeamContext(_currentProject, webApiTeam.Name)))
+                _workHttpClient.PostTeamIterationAsync(teamSettingsIteration, teamContext).SyncResult();
+        }
+
+        private static void CreateIteration(string iterationNamePrefix, int iterationNumber, DateTime startDate)
+        {
+            var workItemClassificationNode = new WorkItemClassificationNode
+            {
+                Name = $"{iterationNamePrefix} {iterationNumber}",
+                StructureType = TreeNodeStructureType.Iteration,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "startDate", startDate },
+                    // Need to count the first day when calculating the finish date 
+                    { "finishDate", startDate.AddDays(_iterationLength - 1) }
+                }
+            };
+
+            var createdWorkItemClassificationNode = _workItemTrackingHttpClient.CreateOrUpdateClassificationNodeAsync(
+                workItemClassificationNode,
+                _currentProject,
+                TreeStructureGroup.Iterations).Result;
+
+            if (createdWorkItemClassificationNode == null)
+                throw new Exception($"Unable to create the iteration `{_currentProject} - {iterationNamePrefix}`");
+
+            AssignIterationToTeams(createdWorkItemClassificationNode);
+        }
+
+        private static void CreateIterations(string iterationNamePrefix, int iterationsToCreate, int iterationNumber, DateTime startDate)
+        {
+            var iterationsCreated = 0;
+
+            while (iterationsCreated < iterationsToCreate)
+            {
+                CreateIteration(iterationNamePrefix, iterationNumber, startDate);
+
+                iterationsCreated++;
+                iterationNumber++;
+                startDate = startDate.AddDays(_iterationLength);
+            }
+        }
+
+        private static WorkItemClassificationNode GetCurrentIterationWorkItemClassificationNode(WorkItemClassificationNode workItemClassificationNode)
+        {
+            return workItemClassificationNode.Children
+                .SingleOrDefault(wicn => (DateTime)wicn.Attributes[StartDateKey] < _today && _today < (DateTime)wicn.Attributes[FinishDateKey]);
+        }
+
+        private static WorkItemClassificationNode GetRootIterationWorkItemClassificationNode(string project)
+        {
+            return _workItemTrackingHttpClient.GetClassificationNodeAsync(
+                project,
+                TreeStructureGroup.Iterations,
+                null,
+                1).Result;
+        }
+
+        private static void Main(string[] args)
+        {
+            _configuration = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables()
+                .AddJsonFile(AppSettingsFile, true, true)
+#if DEBUG
+                .AddUserSecrets<Program>()
+#endif
+                .Build();
+
+            _today = DateTime.Now;
+
+            var azureDevOpsPat = _configuration.GetSection("AzureDevOps:PersonalAccessToken").Value;
+            var azureDevOpsUri = _configuration.GetSection("AzureDevOps:Uri").Value;
+            var iterationsToCreate = int.Parse(_configuration.GetSection("AzureDevOps:IterationsToCreate").Value);
+            var iterationNamePrefix = _configuration.GetSection("AzureDevOps:IterationNamePrefix").Value;
+
+            _iterationLength = int.Parse(_configuration.GetSection("AzureDevOps:IterationLength").Value);
+
+            var projects = _configuration
+                .GetSection("AzureDevOps:Projects")
+                .GetChildren()
+                .AsEnumerable()
+                .Select(configurationSection => configurationSection.Value);
+
+            _vssConnection = new VssConnection(new Uri(azureDevOpsUri), new VssBasicCredential(string.Empty, azureDevOpsPat));
+
+            _workHttpClient = _vssConnection.GetClient<WorkHttpClient>();
+            _workItemTrackingHttpClient = _vssConnection.GetClient<WorkItemTrackingHttpClient>();
+            _teamHttpClient = _vssConnection.GetClient<TeamHttpClient>();
+
+            foreach (var project in projects)
+            {
+                _currentProject = project;
+
+                _currentTeams = _teamHttpClient.GetTeamsAsync(project).Result;
+
+                var azureDevOpsIterations = GetRootIterationWorkItemClassificationNode(project);
+
+                //TODO: Check for default iterations
+
+                var hasIterations = azureDevOpsIterations.HasChildren ?? false;
+                var hasDatesSet = azureDevOpsIterations.Children?
+                                      .All(workItemClassificationNode =>
+                                          workItemClassificationNode.Attributes != null &&
+                                          workItemClassificationNode.Attributes.ContainsKey(StartDateKey) &&
+                                          workItemClassificationNode.Attributes.ContainsKey(FinishDateKey))
+                                  ?? false;
+
+                if (!hasIterations)
+                {
+                    var startDate = DateTime.Parse(_configuration.GetSection("AzureDevOps:IterationOneDate").Value);
+
+                    CreateIterations(iterationNamePrefix, iterationsToCreate, 1, startDate);
+                }
+                else if (hasDatesSet)
+                {
+                    int iterationNumber;
+                    DateTime iterationStartDate;
+
+                    var currentIteration = GetCurrentIterationWorkItemClassificationNode(azureDevOpsIterations);
+
+                    while (currentIteration == null)
+                    {
+                        var latestIteration = azureDevOpsIterations.Children.OrderByDescending(wicn => (DateTime)wicn.Attributes[FinishDateKey]).First();
+
+                        iterationNumber = int.Parse(latestIteration.Name.Replace($"{iterationNamePrefix} ", string.Empty)) + 1;
+                        iterationStartDate = ((DateTime)latestIteration.Attributes[FinishDateKey]).AddDays(1);
+
+                        CreateIteration(iterationNamePrefix, iterationNumber, iterationStartDate);
+
+                        azureDevOpsIterations = GetRootIterationWorkItemClassificationNode(project);
+                        currentIteration = GetCurrentIterationWorkItemClassificationNode(azureDevOpsIterations);
+                    }
+
+                    iterationNumber = int.Parse(currentIteration.Name.Replace($"{iterationNamePrefix} ", string.Empty)) + 1;
+                    iterationStartDate = ((DateTime)currentIteration.Attributes[FinishDateKey]).AddDays(1);
+
+                    for (var index = 0; index < iterationsToCreate; index++)
+                    {
+                        var iterationName = $"{iterationNamePrefix} {iterationNumber}";
+
+                        if (azureDevOpsIterations.Children.All(wicn => wicn.Name != iterationName))
+                            CreateIteration(iterationNamePrefix, iterationNumber, iterationStartDate);
+
+                        iterationNumber++;
+                        iterationStartDate = iterationStartDate.AddDays(_iterationLength);
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException("Logic for the current state of Azure DevOps has not been implemented.");
+                }
+            }
         }
     }
 }

--- a/src/Webstorm.AzureDevOps.Iterations.Generate/Program.cs
+++ b/src/Webstorm.AzureDevOps.Iterations.Generate/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Webstorm.AzureDevOps.Iterations.Generate
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Webstorm.AzureDevOps.Iterations.Generate/Webstorm.AzureDevOps.Iterations.Generate.csproj
+++ b/src/Webstorm.AzureDevOps.Iterations.Generate/Webstorm.AzureDevOps.Iterations.Generate.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <UserSecretsId>5fdb0978-45fc-4317-b8a7-45b2d00af111</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Webstorm.AzureDevOps.Iterations.sln
+++ b/src/Webstorm.AzureDevOps.Iterations.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Webstorm.AzureDevOps.Iterations.Generate", "Webstorm.AzureDevOps.Iterations.Generate\Webstorm.AzureDevOps.Iterations.Generate.csproj", "{3EA46465-2AD5-4897-B05B-9171E69C1A81}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|x64.Build.0 = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Debug|x86.Build.0 = Debug|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|x64.ActiveCfg = Release|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|x64.Build.0 = Release|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|x86.ActiveCfg = Release|Any CPU
+		{3EA46465-2AD5-4897-B05B-9171E69C1A81}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The solution is simple and basic right now. It creates sprints with their dates sets and assigns them to the teams of the project. The assumptions are:

- The entire project uses the same sprint cadence
- All teams need the created sprints
- You are starting with a clean slate (i.e., no default created sprints)
- You have existing sprints but dates must be set correctly
- Your sprints have an incrementing number (i.e., `Sprint 1`, `Sprint 2`, `Sprint 3`, etc.)